### PR TITLE
[feature] nyt preview shows on d3 mouseover

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,18 @@
   <head>
     <meta charset="utf-8">
     <title>immedia</title>
+    <style>
+
+    #preview {
+      width: 500px;
+      height: 600px;
+      border-style: solid;
+      border-color: gray;
+      border-width: 1px;
+      border-radius: 10px;
+    }
+
+    </style>
   </head>
   <body>
     <div id='container'></div>

--- a/client/src/results_page/nytpreview.jsx
+++ b/client/src/results_page/nytpreview.jsx
@@ -1,0 +1,52 @@
+var React = require('react');
+
+var frameCache = {};
+
+var NytPreview = React.createClass({
+  
+  render: function() {
+    
+    var previewItem = this.props.previewItem;
+    var preview = false;
+
+    var previewData;
+
+    if (!frameCache[previewItem.url]) {
+      $.ajax({
+        type: 'GET',
+        url: 'http://api.embed.ly/1/oembed?key=7fd3eb5aa6f34be7be07cb9015f01e23&url=' + previewItem.url,
+        dataType: 'jsonp',
+        success: function(data) {
+          console.log('success!', data);
+          frameCache[previewItem.url] = data;
+          previewData = data;
+          previewData.thumbnail_height = 0.45*previewData.thumbnail_height;
+          previewData.thumbnail_width = 0.45*previewData.thumbnail_width;
+          preview = true;
+        },
+        failure: function(data) {
+          console.log('whateva');
+        }
+      })
+    } else {
+      console.log('cached data:', frameCache[previewItem.url]);
+      previewData = frameCache[previewItem.url];
+      preview = true;
+    }
+
+
+
+    return (
+      <div>
+        <h1>{ previewData.title }</h1>
+        <h3>{ previewData.author_name }</h3>
+        <img src={ previewData.thumbnail_url } height={ previewData.thumbnail_height } width= { previewData.thumbnail_width }></img>
+        <p>{ previewData.description }</p>
+      </div>
+      );
+  }
+
+
+})
+
+module.exports = NytPreview;

--- a/client/src/results_page/preview.jsx
+++ b/client/src/results_page/preview.jsx
@@ -1,31 +1,33 @@
 var React = require('react');
 
+var NytPreview = require('./nytpreview.jsx');
+
 var Preview = React.createClass({
 
   render: function() {
 
-    console.log('preview is rendered with item:', this.props.previewItem)
-    
     var previewItem = this.props.previewItem;
-
-    // $.ajax({
-    //   type: 'GET',
-    //   url: 'http://' + previewItem.url,
-    //   dataType: 'jsonp',
-    //   success: function(data) {
-    //     console.log('success!', data);
-    //   },
-    //   failure: function(data) {
-    //     console.log('whateva');
-    //   }
-    // })
-
-    return (
+    var source = previewItem.source;
+    
+    if (source == 'nyt') {
+      var nyt = true;
+    } else if (source == 'youtube') {
+      var youtube = true;
+    } else if (source == 'twitter') {
+      var twitter = true;
+    }
+    
+    return(
       <div>
-        <h1>{ previewItem.title }</h1>
-      </div>  
-      );
+
+      { nyt ? <NytPreview previewItem={ previewItem } /> : null }
+      { twitter ? <TwitterPreview previewItem={ previewItem } /> : null }
+      { youtube ? <YouTubePreview previewItem={ previewItem } /> : null }
+
+      </div>
+      )
   }
+
 });
 
 module.exports = Preview;

--- a/client/src/results_page/treetimeline.jsx
+++ b/client/src/results_page/treetimeline.jsx
@@ -130,6 +130,8 @@ var TreeTimeLine = React.createClass({
         date: item.date,
         url: item.url,
         img: item.img,
+        source: item.parent.source,
+        id: item.id
       });
   },
 


### PR DESCRIPTION
Nested views available within preview component for nyt, youtube, and twitter preview's. Mouseover delivers item's title, url, source, img (if applicable), & id.
